### PR TITLE
Fix for integer division error

### DIFF
--- a/cartesius/colors.py
+++ b/cartesius/colors.py
@@ -11,10 +11,10 @@ def get_color(color):
         temp = color
         blue = temp % 256
 
-        temp = temp / 256
+        temp = int(temp / 256)
         green = temp % 256
 
-        temp = temp / 256
+        temp = int(temp / 256)
         red = temp % 256
 
         return (red, green, blue)


### PR DESCRIPTION
```
$ python3 create_images_and_readme.py
Processing <function test_circles at 0x10cda6400>
written: graph-0-0.png
written: graph-0-1.png
Processing <function test_piechart_1 at 0x10d1d4a60>
written: graph-1-0.png
written: graph-1-1.png
Processing <function test_piechart_2 at 0x10d1ed1e0>
written: graph-2-0.png
written: graph-2-1.png
Processing <function test_barchart_1 at 0x10d1edb70>
written: graph-3-0.png
written: graph-3-1.png
Processing <function test_barchart_2 at 0x10d1edbf8>
written: graph-4-0.png
written: graph-4-1.png
Processing <function test_barchart_horizontal at 0x10d1edc80>
written: graph-5-0.png
written: graph-5-1.png
Processing <function test_barchart_with_generator at 0x10d1edd08>
written: graph-6-0.png
written: graph-6-1.png
Traceback (most recent call last):
  File "create_images_and_readme.py", line 698, in <module>
    images = function()
  File "create_images_and_readme.py", line 216, in test_function
    return coordinate_system.draw(300, 200), coordinate_system.draw(300, 200, antialiasing=True)
  File "/Users/loos/Documents/schule/src/PycharmProjects/cartesius/cartesius/main.py", line 246, in draw
        self.__draw_elements(image=image, draw=draw, draw_handler=draw_handler,     hide_x_axis=hide_x_axis, hide_y_axis=hide_y_axis)
  File "/Users/loos/Documents/schule/src/PycharmProjects/cartesius/cartesius/main.py", line 211, in __draw_elements
    element.draw(image=image, draw=draw, draw_handler=draw_handler)
  File "/Users/loos/Documents/schule/src/PycharmProjects/cartesius/cartesius/main.py", line 304, in draw
    self.process_image(draw_handler)
  File "/Users/loos/Documents/schule/src/PycharmProjects/cartesius/cartesius/charts.py", line 373, in process_image
    draw_handler.draw_line(x1, y1, x2, y2, self.get_color_with_transparency(self.color))
  File "/Users/loos/Documents/schule/src/PycharmProjects/cartesius/cartesius/main.py", line 397, in draw_line
    self.pil_draw.line((image_x1, image_y1, image_x2, image_y2), color)
  File "/usr/local/lib/python3.5/site-packages/PIL/ImageDraw.py", line 177, in line
    ink, fill = self._getink(fill)
  File "/usr/local/lib/python3.5/site-packages/PIL/ImageDraw.py", line 125, in _getink
    ink = self.draw.draw_ink(ink, self.mode)
TypeError: integer argument expected, got float
```
